### PR TITLE
Add custom base URL and SOCKS proxy support for Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,11 @@ GEMINI_API_KEY=your-gemini-api-key-here
 # Optional: Use a different model (default: gemini-2.5-pro)
 # GEMINI_MODEL=gemini-2.5-pro
 
+# Optional: Custom base URL for API server (default: uses official Google API)
+# GEMINI_BASE_URL=your-gemini-base-url
+
+# Optional: API version (default: uses beta API, set to v1 for custom endpoints)
+# GEMINI_API_VERSION=v1
+
 # Optional: Custom system prompt for Gemini behavior
 # SYSTEM_PROMPT="Your custom system prompt here..."

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 peterkrueck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gemini_mcp.py
+++ b/gemini_mcp.py
@@ -22,7 +22,13 @@ if not os.getenv('GEMINI_API_KEY'):
     sys.exit(1)
 
 # Initialize client
-client = genai.Client(api_key=os.getenv('GEMINI_API_KEY'))
+client_kwargs = {'api_key': os.getenv('GEMINI_API_KEY')}
+if os.getenv('GEMINI_BASE_URL'):
+    client_kwargs['http_options'] = types.HttpOptions(
+        base_url=os.getenv('GEMINI_BASE_URL'),
+        api_version=os.getenv('GEMINI_API_VERSION', 'v1')  # Default to v1 for custom endpoints
+    )
+client = genai.Client(**client_kwargs)
 
 # Configuration
 MODEL_NAME = os.getenv('GEMINI_MODEL', 'gemini-2.5-pro')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 google-genai>=0.5.0
 mcp>=1.0.0
 pydantic>=2.0.0
+socksio>=1.0.0


### PR DESCRIPTION
## Summary
- Add support for custom Gemini API base URLs via GEMINI_BASE_URL environment variable
- Add support for custom API versions via GEMINI_API_VERSION environment variable
- Add SOCKS proxy support for enhanced connectivity options
- Add socksio dependency for SOCKS proxy handling

## Test plan
- [ ] Test with default Google API endpoint
- [x] Test with custom base URL configuration
- [x] Test SOCKS proxy functionality
- [x] Verify backward compatibility with existing configurations